### PR TITLE
Add scheduling to runner class

### DIFF
--- a/cognite/extractorutils/rest/extractor.py
+++ b/cognite/extractorutils/rest/extractor.py
@@ -233,7 +233,7 @@ class RestExtractor(Extractor[RestConfig]):
             runners.append(runner)
 
         for runner in runners:
-            runner.thread.join()
+            runner.join()
 
 
 class EndpointRunner:
@@ -272,7 +272,7 @@ class EndpointRunner:
             call = self.call(next_url)
             next_url = self._try_get_next_page(call)
 
-    def run(self):
+    def run(self) -> None:
         def loop() -> None:
             for _ in throttled_loop(
                 target_time=self.endpoint.interval, cancelation_token=self.extractor.cancelation_token
@@ -284,6 +284,10 @@ class EndpointRunner:
             name=f"EndpointRunner-{self.endpoint.path}",
         )
         self.thread.start()
+
+    def join(self) -> None:
+        if self.thread is not None:
+            self.thread.join()
 
 
 T = TypeVar("T")

--- a/cognite/extractorutils/rest/extractor.py
+++ b/cognite/extractorutils/rest/extractor.py
@@ -24,6 +24,7 @@ import requests
 from cognite.extractorutils.authentication import Authenticator, AuthenticatorConfig
 from cognite.extractorutils.base import Extractor
 from cognite.extractorutils.configtools import BaseConfig
+from cognite.extractorutils.throttle import throttled_loop
 from cognite.extractorutils.uploader import EventUploadQueue, RawUploadQueue, TimeSeriesUploadQueue
 from more_itertools import peekable
 
@@ -224,8 +225,15 @@ class RestExtractor(Extractor[RestConfig]):
         if not self.started:
             raise ValueError("You must run the extractor in a context manager")
 
+        runners = []
+
         for endpoint in self.endpoints:
-            EndpointRunner(self, endpoint).run()
+            runner = EndpointRunner(self, endpoint)
+            runner.run()
+            runners.append(runner)
+
+        for runner in runners:
+            runner.thread.join()
 
 
 class EndpointRunner:
@@ -260,12 +268,22 @@ class EndpointRunner:
     def exhaust_endpoint(self) -> None:
         next_url = HttpUrl(urljoin(self.extractor.base_url, self.endpoint.path))
 
-        while next_url is not None:
+        while next_url is not None and not self.extractor.cancelation_token.is_set():
             call = self.call(next_url)
             next_url = self._try_get_next_page(call)
 
-    def run(self) -> None:
-        self.exhaust_endpoint()
+    def run(self):
+        def loop() -> None:
+            for _ in throttled_loop(
+                target_time=self.endpoint.interval, cancelation_token=self.extractor.cancelation_token
+            ):
+                self.exhaust_endpoint()
+
+        self.thread = threading.Thread(
+            target=loop if self.endpoint.interval is not None else self.exhaust_endpoint,
+            name=f"EndpointRunner-{self.endpoint.path}",
+        )
+        self.thread.start()
 
 
 T = TypeVar("T")


### PR DESCRIPTION
Use throttled loops to run enpoints on a schedule (using the interval
arguement). If an extraction takes longer than the given interval, the
execution will just start immediately after the previous job is done.