### PR TITLE
Make path variable optionally callable and config class configurable

### DIFF
--- a/cognite/extractorutils/rest/http.py
+++ b/cognite/extractorutils/rest/http.py
@@ -75,7 +75,7 @@ class HttpCall(Generic[ResponseType]):
 class Endpoint(Generic[ResponseType]):
     implementation: Callable[[ResponseType], CdfTypes]
     method: HttpMethod
-    path: str
+    path: Union[str, Callable[[], str]]
     query: Dict[str, Any]
     headers: Dict[str, Union[str, Callable[[], str]]]
     body: Optional[RequestBody]


### PR DESCRIPTION
If path is callable, call it, otherwise use the string directly (like
we do for headers, etc).

I think more advanced use cases would need a custom config class, so
add support for that as well.