### PR TITLE
Change the way queries are throttled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Temp files
+states.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cognite/extractorutils/rest/extractor.py
+++ b/cognite/extractorutils/rest/extractor.py
@@ -124,7 +124,7 @@ class RestExtractor(UploaderExtractor[CustomRestConfig]):
         config_class: Type[CustomRestConfig] = RestConfig,
         use_default_state_store: bool = True,
         config_file_path: Optional[str] = None,
-        num_parallel_requests: int = 10
+        num_parallel_requests: int = 10,
     ):
         super(RestExtractor, self).__init__(
             name=name,
@@ -390,11 +390,7 @@ class RestExtractor(UploaderExtractor[CustomRestConfig]):
             # accurate.
             if self.n_executing == 0 and self.call_queue.empty():
                 return waiting.call if waiting is not None else None
-            to_wait = (
-                self._min_check_interval
-                if waiting is None
-                else min(self._min_check_interval, waiting.call.call_when - time.time())
-            )
+            to_wait = self._min_check_interval if waiting is None else waiting.call.call_when - time.time()
             if waiting is not None and to_wait <= 0:
                 return waiting.call
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,14 @@ black = "*"
 isort = "*"
 mypy = "*"
 flake8 = "*"
-pytest = "^6.2.5"
+pytest = "^7.2.0"
 pytest-cov = "^2.8.1"
 sphinx = "^4.2.0"
 sphinx-rtd-theme = "^1.0.0"
 pre-commit = "^2.19.0"
 types-requests = "^2.26.0"
 twine = "^3.8.0"
+requests-mock = "^1.10.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils-rest"
-version = "0.2.3"
+version = "0.3.0"
 description = "REST extention for the Cognite extractor-utils framework"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"
@@ -21,7 +21,7 @@ line_length=120                # corresponds to -w  flag
 multi_line_output=3            # corresponds to -m  flag
 include_trailing_comma=true    # corresponds to -tc flag
 skip_glob = '^((?!py$).)*$'    # this makes sort all Python files
-known_third_party = ["arrow", "dacite", "requests"]
+known_third_party = ["arrow", "dacite", "requests", "requests_mock"]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"

--- a/tests/unit/test_config.yml
+++ b/tests/unit/test_config.yml
@@ -1,0 +1,9 @@
+version: 1
+
+cognite:
+  project: test
+  api-key: test
+
+logger:
+  console:
+    level: DEBUG

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -1,0 +1,137 @@
+from dataclasses import dataclass
+from typing import Generator, List, Optional
+
+import pytest
+from requests_mock import Mocker
+import requests
+
+
+from cognite.extractorutils.rest import RestExtractor
+from cognite.extractorutils.rest.http import HttpCall, HttpUrl
+from cognite.extractorutils.uploader_types import RawRow
+from cognite.client.data_classes import Row
+
+@dataclass
+class MyResponseType:
+    it: int
+    cursor: Optional[str]
+
+@dataclass
+class ResponseTypeList:
+    items: List[MyResponseType]
+
+def get_extractor(idx: int) -> RestExtractor:
+    extractor = RestExtractor(
+        name=f"Test extractor {idx}",
+        description="test",
+        version="1.0.0",
+        base_url="http://mybaseurl.foo/",
+        config_file_path="tests/unit/test_config.yml",
+    )
+    extractor.cancelation_token.clear()
+    extractor._min_check_interval = 0.1
+    return extractor
+
+
+class RawMocker:
+    def __init__(self, mock: Mocker):
+        self.calls = 0
+        def raw_req_callback(request: requests.Request, context):
+            self.calls += 1
+            return {}
+
+        self.mock = mock
+        self.mock.post(
+            url="https://api.cognitedata.com/api/v1/projects/test/raw/dbs/mydb/tables/mytable/rows",
+            json=raw_req_callback
+        )
+
+
+class TestRequests:
+    def test_simple_get(self, requests_mock: Mocker):
+        requests_mock.get(url="http://mybaseurl.foo/path", json={"it": 1, "cursor": None})
+        raw = RawMocker(requests_mock)
+        extractor = get_extractor(0)
+        @extractor.get("path", response_type=MyResponseType)
+        def get_test_resp(data: MyResponseType) -> Generator[RawRow, None, None]:
+            yield RawRow(
+                "mydb",
+                "mytable",
+                Row(
+                    key=data.it,
+                    columns={
+                        "test": "test"
+                    }
+                )
+            )
+        with extractor:
+            extractor.run()
+
+        assert raw.calls == 1
+
+    def test_get_list(self, requests_mock: Mocker):
+        requests_mock.get(url="http://mybaseurl.foo/path", json=[{"it": 1, "cursor": None}, {"it": 2, "cursor": None}])
+        raw = RawMocker(requests_mock)
+        extractor = get_extractor(1)
+        @extractor.get("path", response_type=ResponseTypeList)
+        def get_test_resp(data: ResponseTypeList) -> Generator[RawRow, None, None]:
+            for item in data.items:
+                yield RawRow(
+                    "mydb",
+                    "mytable",
+                    Row(
+                        key=item.it,
+                        columns={
+                            "test": "test"
+                        }
+                    )
+                )
+        with extractor:
+            extractor.run()
+
+        assert raw.calls == 1
+        
+    def test_follow_cursor(self, requests_mock: Mocker):
+        def mock_response(request: requests.Request, context):
+            print(request.url)
+            if request.url.endswith("?cursor=some"):
+                return {"it": 2, "cursor": "some2"}
+            elif request.url.endswith("?cursor=some2"):
+                return {"it": 3, "cursor": None}
+            return {"it": 1, "cursor": "some"}
+        requests_mock.get(url="http://mybaseurl.foo/path", json=mock_response)
+        raw = RawMocker(requests_mock)
+        extractor = get_extractor(2)
+        num_page = 0
+        resps = []
+        def test_next_page(call: HttpCall) -> Optional[HttpUrl]:
+            nonlocal num_page
+            num_page += 1
+            if call.response.cursor is not None:
+                call.url.query["cursor"] = call.response.cursor
+                return call.url
+            return None
+
+        @extractor.get("path", response_type=MyResponseType, next_page=test_next_page)
+        def get_test_resp(data: MyResponseType) -> Generator[RawRow, None, None]:
+            nonlocal resps
+            resps.append(data)
+            yield RawRow(
+                "mydb",
+                "mytable",
+                Row(
+                    key=data.it,
+                    columns={
+                        "test": "test"
+                    }
+                )
+            )
+
+        with extractor:
+            extractor.run()
+
+        assert raw.calls == 1
+        assert num_page == 3
+        assert len(resps) == 3
+        assert resps[0].it == 1
+        assert resps[1].it == 2

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -1,24 +1,25 @@
 from dataclasses import dataclass
-from typing import Generator, List, Optional
+from typing import Any, Generator, List, Optional
 
-import pytest
-from requests_mock import Mocker
 import requests
-
+from cognite.client.data_classes import Row
+from cognite.extractorutils.uploader_types import RawRow
+from requests_mock import Mocker
 
 from cognite.extractorutils.rest import RestExtractor
 from cognite.extractorutils.rest.http import HttpCall, HttpUrl
-from cognite.extractorutils.uploader_types import RawRow
-from cognite.client.data_classes import Row
+
 
 @dataclass
 class MyResponseType:
     it: int
     cursor: Optional[str]
 
+
 @dataclass
 class ResponseTypeList:
     items: List[MyResponseType]
+
 
 def get_extractor(idx: int) -> RestExtractor:
     extractor = RestExtractor(
@@ -36,74 +37,63 @@ def get_extractor(idx: int) -> RestExtractor:
 class RawMocker:
     def __init__(self, mock: Mocker):
         self.calls = 0
-        def raw_req_callback(request: requests.Request, context):
+
+        def raw_req_callback(request: requests.Request, context: Any) -> dict:
             self.calls += 1
             return {}
 
         self.mock = mock
         self.mock.post(
             url="https://api.cognitedata.com/api/v1/projects/test/raw/dbs/mydb/tables/mytable/rows",
-            json=raw_req_callback
+            json=raw_req_callback,
         )
 
 
 class TestRequests:
-    def test_simple_get(self, requests_mock: Mocker):
+    def test_simple_get(self, requests_mock: Mocker) -> None:
         requests_mock.get(url="http://mybaseurl.foo/path", json={"it": 1, "cursor": None})
         raw = RawMocker(requests_mock)
         extractor = get_extractor(0)
+
         @extractor.get("path", response_type=MyResponseType)
         def get_test_resp(data: MyResponseType) -> Generator[RawRow, None, None]:
-            yield RawRow(
-                "mydb",
-                "mytable",
-                Row(
-                    key=data.it,
-                    columns={
-                        "test": "test"
-                    }
-                )
-            )
+            yield RawRow("mydb", "mytable", Row(key=data.it, columns={"test": "test"}))
+
         with extractor:
             extractor.run()
 
         assert raw.calls == 1
 
-    def test_get_list(self, requests_mock: Mocker):
+    def test_get_list(self, requests_mock: Mocker) -> None:
         requests_mock.get(url="http://mybaseurl.foo/path", json=[{"it": 1, "cursor": None}, {"it": 2, "cursor": None}])
         raw = RawMocker(requests_mock)
         extractor = get_extractor(1)
+
         @extractor.get("path", response_type=ResponseTypeList)
         def get_test_resp(data: ResponseTypeList) -> Generator[RawRow, None, None]:
             for item in data.items:
-                yield RawRow(
-                    "mydb",
-                    "mytable",
-                    Row(
-                        key=item.it,
-                        columns={
-                            "test": "test"
-                        }
-                    )
-                )
+                yield RawRow("mydb", "mytable", Row(key=item.it, columns={"test": "test"}))
+
         with extractor:
             extractor.run()
 
         assert raw.calls == 1
-        
-    def test_follow_cursor(self, requests_mock: Mocker):
-        def mock_response(request: requests.Request, context):
+
+    def test_follow_cursor(self, requests_mock: Mocker) -> None:
+        def mock_response(request: requests.Request, context: Any) -> dict:
             print(request.url)
             if request.url.endswith("?cursor=some"):
                 return {"it": 2, "cursor": "some2"}
             elif request.url.endswith("?cursor=some2"):
                 return {"it": 3, "cursor": None}
             return {"it": 1, "cursor": "some"}
+
         requests_mock.get(url="http://mybaseurl.foo/path", json=mock_response)
         raw = RawMocker(requests_mock)
         extractor = get_extractor(2)
         num_page = 0
         resps = []
+
         def test_next_page(call: HttpCall) -> Optional[HttpUrl]:
             nonlocal num_page
             num_page += 1
@@ -116,16 +106,7 @@ class TestRequests:
         def get_test_resp(data: MyResponseType) -> Generator[RawRow, None, None]:
             nonlocal resps
             resps.append(data)
-            yield RawRow(
-                "mydb",
-                "mytable",
-                Row(
-                    key=data.it,
-                    columns={
-                        "test": "test"
-                    }
-                )
-            )
+            yield RawRow("mydb", "mytable", Row(key=data.it, columns={"test": "test"}))
 
         with extractor:
             extractor.run()


### PR DESCRIPTION
Also add a few tests.

This fundamentally changes how the extractor executes queries. Instead of running each registered query in a separate thread, run a common executor that waits on a priority queue with the scheduled runs.

 - Retrieve HTTP call from priority queue, the priority is equal to the time it is expected to execute, or 0 if it should be executed as soon as possible.
 - If the call has a time set to greater than 0, we begin waiting on the queue.
 - Since new calls added to the queue may have lower priority than the one we are currently waiting for, we have to check if we should wait before moving on.
 - If there is no call in the queue, we may abort only when there also is no running call. Rather than doing some crazy gating here, I just ended up with an integer behind a lock. It should be sound. When we are not waiting for a call we set a default timeout (1 second), to allow checking for whether all calls have terminated without anything being added to the queue.

This now technically allows adding new calls to the execution queue while the extractor is running, though doing so from outside of another call would be very prone to unexpected behavior.