### PR TITLE
Add support for nested queries

### DIFF
--- a/example.py
+++ b/example.py
@@ -48,7 +48,6 @@ extractor = RestExtractor(
     name="Event extractor",
     description="Testytesty",
     version="1.0.0",
-    base_url="https://api.cognitedata.com/api/v1/projects/jetfiretest/",
 )
 
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -16,7 +16,16 @@ cognite:
             - ${COGNITE_BASE_URL}/.default
 
 source:
+  # The source base url. The examples read from CDF
+  base_url: ${COGNITE_BASE_URL}/api/v1/projects/${COGNITE_PROJECT}/
   auth:
-    basic:
-      username: user
-      password: pass
+    #basic:
+    #  username: user
+    #  password: pass
+    oauth:
+      token-url: ${COGNITE_TOKEN_URL}
+
+      client-id: ${COGNITE_CLIENT_ID}
+      secret: ${COGNITE_CLIENT_SECRET}
+      scopes:
+          - ${COGNITE_BASE_URL}/.default

--- a/example_nested.py
+++ b/example_nested.py
@@ -1,0 +1,100 @@
+#  Copyright 2022 Cognite AS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from dataclasses import dataclass
+from typing import Generator, List, Optional
+
+from cognite.client.data_classes import Row
+from cognite.extractorutils.uploader_types import RawRow
+
+from cognite.extractorutils.rest import RestExtractor
+from cognite.extractorutils.rest.http import HttpMethod
+
+# Paginate timeseries belonging to a specific list of assets
+
+@dataclass
+class RawAsset:
+    externalId: Optional[str]
+    name: str
+    id: Optional[int]
+
+
+@dataclass
+class RawTimeSeries:
+    externalId: Optional[str]
+    name: Optional[str]
+    id: Optional[int]
+
+@dataclass
+class AssetsList:
+    items: List[RawAsset]
+    nextCursor: Optional[str]
+
+@dataclass
+class TimeSeriesList:
+    items: List[RawTimeSeries]
+    nextCursor: Optional[str]
+
+
+extractor = RestExtractor(
+    name="Time series by asset name extractor",
+    description="Testytesty",
+    version="1.0.0",
+)
+
+def get_timeseries_alt(tss: TimeSeriesList) -> Generator[RawRow, None, None]:
+    for ts in tss.items:
+        yield RawRow(
+            db_name="ts_byasset",
+            table_name="tss",
+            row=Row(
+                key=ts.id,
+                columns={
+                    "name": ts.name,
+                    "id": ts.id,
+                    "externalId": ts.externalId
+                }
+            )
+        )
+
+@extractor.post("assets/list", body={"filter": {"name": "PubSubGroupType"}, "limit": 1000}, response_type=AssetsList)
+def get_assets_alt(assets: AssetsList) -> Generator[RawRow, None, None]:
+    ids = []
+    for asset in assets.items:
+        ids.append(asset.id)
+        yield RawRow(
+            db_name="ts_byasset",
+            table_name="assets",
+            row=Row(
+                key=asset.id,
+                columns={
+                    "name": asset.name,
+                    "id": asset.id,
+                    "externalId": asset.externalId
+                }
+            )
+        )
+    
+    if len(ids) > 0:
+        extractor.add_endpoint(
+            method=HttpMethod.POST,
+            implementation=get_timeseries_alt,
+            path="timeseries/list",
+            body={"filter": {"assetSubtreeIds": [{"id": id} for id in ids]}},
+            response_type=TimeSeriesList
+        )
+
+
+with extractor:
+    extractor.run()

--- a/example_nested.py
+++ b/example_nested.py
@@ -23,6 +23,7 @@ from cognite.extractorutils.rest.http import HttpMethod
 
 # Paginate timeseries belonging to a specific list of assets
 
+
 @dataclass
 class RawAsset:
     externalId: Optional[str]
@@ -36,10 +37,12 @@ class RawTimeSeries:
     name: Optional[str]
     id: Optional[int]
 
+
 @dataclass
 class AssetsList:
     items: List[RawAsset]
     nextCursor: Optional[str]
+
 
 @dataclass
 class TimeSeriesList:
@@ -53,20 +56,15 @@ extractor = RestExtractor(
     version="1.0.0",
 )
 
+
 def get_timeseries_alt(tss: TimeSeriesList) -> Generator[RawRow, None, None]:
     for ts in tss.items:
         yield RawRow(
             db_name="ts_byasset",
             table_name="tss",
-            row=Row(
-                key=ts.id,
-                columns={
-                    "name": ts.name,
-                    "id": ts.id,
-                    "externalId": ts.externalId
-                }
-            )
+            row=Row(key=ts.id, columns={"name": ts.name, "id": ts.id, "externalId": ts.externalId}),
         )
+
 
 @extractor.post("assets/list", body={"filter": {"name": "PubSubGroupType"}, "limit": 1000}, response_type=AssetsList)
 def get_assets_alt(assets: AssetsList) -> Generator[RawRow, None, None]:
@@ -76,23 +74,16 @@ def get_assets_alt(assets: AssetsList) -> Generator[RawRow, None, None]:
         yield RawRow(
             db_name="ts_byasset",
             table_name="assets",
-            row=Row(
-                key=asset.id,
-                columns={
-                    "name": asset.name,
-                    "id": asset.id,
-                    "externalId": asset.externalId
-                }
-            )
+            row=Row(key=asset.id, columns={"name": asset.name, "id": asset.id, "externalId": asset.externalId}),
         )
-    
+
     if len(ids) > 0:
         extractor.add_endpoint(
             method=HttpMethod.POST,
             implementation=get_timeseries_alt,
             path="timeseries/list",
             body={"filter": {"assetSubtreeIds": [{"id": id} for id in ids]}},
-            response_type=TimeSeriesList
+            response_type=TimeSeriesList,
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils-rest"
-version = "0.3.0"
+version = "0.4.0"
 description = "REST extention for the Cognite extractor-utils framework"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Also update the example configs to actually work with example.py, and add a new example_nested.py which demonstrates nested queries.

The changes in the extractor are small:

 - Add a new add_endpoint method used to register new endpoints/calls dynamically
 - Refactor the old endpoint methods to optionally add to the live list of endpoints if the extractor is running when they are called.