### PR TITLE
Flexible return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ with extractor:
 
 A full example is provided in the [`example.py`](./example.py) file.
 
+### The return type
+If the return type is set to `cognite.extractorutils.rest.http.JsonType` then the raw json payload will be passed to the handler.
+This is useful for cases where the payload is hard or impossible to describe with data classes.
+
+If the return type is set to `requests.Response`, the raw response message itself is passed to the handler.
+
 ### Lists at the root
 Using Python dataclasses we're not able to express JSON structures where the root element 
 is a list. To get around that responses of this nature will be automatically converted to something which can be modeled with Python dataclasses. 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ will be converted to
 }
 ```
 
+This does not apply if the return type is set to `JsonType`.
+
 ## Contributing
 
 We use [poetry](https://python-poetry.org) to manage dependencies and to administrate virtual environments. To develop

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ with extractor:
 A full example is provided in the [`example.py`](./example.py) file.
 
 ### The return type
-If the return type is set to `cognite.extractorutils.rest.http.JsonType` then the raw json payload will be passed to the handler.
+If the return type is set to `cognite.extractorutils.rest.http.JsonBody` then the raw json payload will be passed to the handler.
 This is useful for cases where the payload is hard or impossible to describe with data classes.
 
 If the return type is set to `requests.Response`, the raw response message itself is passed to the handler.
@@ -102,7 +102,7 @@ will be converted to
 }
 ```
 
-This does not apply if the return type is set to `JsonType`.
+This does not apply if the return type is set to `JsonBody`.
 
 ## Contributing
 

--- a/cognite/extractorutils/rest/extractor.py
+++ b/cognite/extractorutils/rest/extractor.py
@@ -39,8 +39,7 @@ from cognite.extractorutils.rest.http import (
     HttpCallResult,
     HttpMethod,
     HttpUrl,
-    JsonType,
-    RequestBody,
+    JsonBody,
     RequestBodyTemplate,
     ResponseType,
 )
@@ -551,7 +550,7 @@ class RestExtractor(UploaderExtractor[CustomRestConfig]):
 
         try:
             print(endpoint.endpoint.response_type)
-            if endpoint.endpoint.response_type == JsonType:
+            if endpoint.endpoint.response_type == JsonBody:
                 response = raw_response.json()
             elif endpoint.endpoint.response_type == Response:
                 response = raw_response
@@ -593,7 +592,7 @@ def _format_body(body: Optional[RequestBodyTemplate]) -> Optional[str]:
     if body is None:
         return None
 
-    def recursive_get_or_call(item: RequestBodyTemplate) -> RequestBody:
+    def recursive_get_or_call(item: RequestBodyTemplate) -> JsonBody:
         if isinstance(item, dict):
             return {k: recursive_get_or_call(v) for k, v in item.items()}
         elif isinstance(item, list):

--- a/cognite/extractorutils/rest/extractor.py
+++ b/cognite/extractorutils/rest/extractor.py
@@ -39,6 +39,7 @@ from cognite.extractorutils.rest.http import (
     HttpCallResult,
     HttpMethod,
     HttpUrl,
+    JsonType,
     RequestBody,
     RequestBodyTemplate,
     ResponseType,
@@ -490,6 +491,7 @@ class RestExtractor(UploaderExtractor[CustomRestConfig]):
                 resp = self._call(endpoint)
                 self._handle_call_response(endpoint.endpoint, resp)
             except Exception as e:
+                self.logger.exception("Error in endpoint {}", endpoint.endpoint.name)
                 errors.append((e, endpoint))
             with lock:
                 self.n_executing -= 1
@@ -548,12 +550,16 @@ class RestExtractor(UploaderExtractor[CustomRestConfig]):
         raw_response = inner_call()
 
         try:
-            data = raw_response.json()
-
-            if isinstance(data, list):
-                data = {"items": data}
-
-            response = dacite.from_dict(endpoint.endpoint.response_type, data)
+            print(endpoint.endpoint.response_type)
+            if endpoint.endpoint.response_type == JsonType:
+                response = raw_response.json()
+            elif endpoint.endpoint.response_type == Response:
+                response = raw_response
+            else:
+                data = raw_response.json()
+                if isinstance(data, list):
+                    data = {"items": data}
+                response = dacite.from_dict(endpoint.endpoint.response_type, data)
 
             result = endpoint.endpoint.implementation(response)
             self.handle_output(result)

--- a/cognite/extractorutils/rest/http.py
+++ b/cognite/extractorutils/rest/http.py
@@ -34,6 +34,7 @@ RequestBodyTemplate = Union[  # type: ignore
     Dict[str, "RequestBodyTemplate"],  # type: ignore
     Callable[[], Dict[str, "RequestBodyTemplate"]],  # type: ignore
 ]
+JsonType = Union[str, int, float, bool, Dict, List]
 
 
 class HttpMethod(Enum):

--- a/cognite/extractorutils/rest/http.py
+++ b/cognite/extractorutils/rest/http.py
@@ -25,7 +25,7 @@ ResponseType = TypeVar("ResponseType")
 
 # Ignoring types here, since recursive types are not yet supported by mypy:  https://github.com/python/mypy/issues/731
 JsonTypes = Union[str, int, float, bool]
-RequestBody = Union[JsonTypes, List["RequestBody"], Dict[str, "RequestBody"]]  # type: ignore
+JsonBody = Union[JsonTypes, List["JsonBody"], Dict[str, "JsonBody"]]  # type: ignore
 RequestBodyTemplate = Union[  # type: ignore
     JsonTypes,
     Callable[[], JsonTypes],
@@ -34,7 +34,6 @@ RequestBodyTemplate = Union[  # type: ignore
     Dict[str, "RequestBodyTemplate"],  # type: ignore
     Callable[[], Dict[str, "RequestBodyTemplate"]],  # type: ignore
 ]
-JsonType = Union[str, int, float, bool, Dict, List]
 
 
 class HttpMethod(Enum):
@@ -105,7 +104,7 @@ class Endpoint(Generic[ResponseType]):
     path: Union[str, Callable[[], str]]
     query: Dict[str, Any]
     headers: Dict[str, Union[str, Callable[[], str]]]
-    body: Optional[RequestBody]
+    body: Optional[JsonBody]
     response_type: Type[ResponseType]
     next_page: Optional[Callable[[HttpCallResult], Optional[HttpUrl]]]
     interval: Optional[int]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-extractor-utils-rest"
-version = "0.4.0"
+version = "0.5.0"
 description = "REST extention for the Cognite extractor-utils framework"
 authors = ["Mathias Lohne <mathias.lohne@cognite.com>"]
 license = "Apache-2.0"

--- a/tests/unit/test_requests.py
+++ b/tests/unit/test_requests.py
@@ -7,8 +7,7 @@ from cognite.extractorutils.uploader_types import RawRow
 from requests_mock import Mocker
 
 from cognite.extractorutils.rest import RestExtractor
-from cognite.extractorutils.rest.http import HttpCallResult, HttpMethod, HttpUrl
-from cognite.extractorutils.rest.http import HttpCallResult, HttpUrl, JsonType, HttpUrl
+from cognite.extractorutils.rest.http import HttpCallResult, HttpMethod, HttpUrl, JsonBody
 
 
 @dataclass
@@ -146,14 +145,14 @@ class TestRequests:
 
         assert call1.call_count == 1
         assert call2.call_count == 2
-        
+
     def test_arbitrary_response(self, requests_mock: Mocker) -> None:
         requests_mock.get(url="http://mybaseurl.foo/path", json=[{"it": 1, "cursor": None}, {"it": 2, "cursor": None}])
         RawMocker(requests_mock)
         extractor = get_extractor(5)
 
-        @extractor.get("path", response_type=JsonType)
-        def get_test_resp(data: JsonType) -> Generator[RawRow, None, None]:
+        @extractor.get("path", response_type=JsonBody)
+        def get_test_resp(data: JsonBody) -> Generator[RawRow, None, None]:
             for item in data:
                 yield RawRow("mydb", "mytable", Row(key=item["it"], columns={"test": "test"}))
 


### PR DESCRIPTION
If the return type is set to `JsonType`, we pass the raw payload. If it is set to `requests.Response` we pass the raw response object itself.

Makes it possible to use this for APIs that return something other than JSON.